### PR TITLE
Relax vibe-core dependency specification

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -3,7 +3,7 @@ description "Telegram Bot API implementation"
 authors     "Pavel Chebotarev"
 license "MIT"
 
-dependency "vibe-core" version="~>1.9.2"
+dependency "vibe-core" version="~>1.9"
 dependency "asdf" version="~>0.5.7"
 dependency "dests" version="~>0.3.1"
 


### PR DESCRIPTION
Since vibe-core uses proper SemVer versioning, including full backwards compatibility within a single major version, it should not be necessary to depend on a particular minor version. I just ran into an issue of not being able to upgrade vibe.d, because that now depends on at least vibe-core 1.10.x.